### PR TITLE
Bug fixes for click package and port number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,34 +3,16 @@ cmake_minimum_required(VERSION 2.8.9)
 
 # Do not remove this line, its required for the correct functionality of the Ubuntu-SDK
 set(UBUNTU_MANIFEST_PATH "manifest.json.in" CACHE INTERNAL "Tells QtCreator location and name of the manifest file")
-
-set(CMAKE_INSTALL_PREFIX "/")
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(DATA_DIR "/")
+find_package(Qt5Core)
+find_package(Qt5Qml)
+find_package(Qt5Quick)
 
-# Project definitions
-set(APP_NAME "wakeit")
-set(APP_TITLE "Wake It!")
-set(APP_DESCRIPTION "Send Wake-on-LAN magic packets")
+# Automatically create moc files
+set(CMAKE_AUTOMOC ON)
 
-set(APP_VERSION_MAJOR 0)
-set(APP_VERSION_MINOR 1)
-set(APP_VERSION_PATCH 4)
-set(APP_VERSION "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_PATCH}")
-
-set(APP_ICON "graphics/${APP_NAME}.png")
-set(APP_DESKTOP "${APP_NAME}.desktop")
-
-set(APP_QML "${APP_NAME}.qml")
-set(APP_EXEC "qmlscene $@ ${APP_QML}")
-
-# Determine the name and arch triplet of the host
-execute_process(
-    COMMAND dpkg-architecture -qDEB_HOST_ARCH
-    OUTPUT_VARIABLE HOST_ARCH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+# Components PATH
 execute_process(
     COMMAND dpkg-architecture -qDEB_HOST_MULTIARCH
     OUTPUT_VARIABLE HOST_MULTIARCH
@@ -40,22 +22,42 @@ execute_process(
 # Specify the directory for the plugin
 set(IMPORTS_DIR "lib/${HOST_MULTIARCH}")
 
-find_package(Qt5Core)
-find_package(Qt5Qml)
-find_package(Qt5Quick)
+# Project definitions
+set(APP_NAME "wakeit")
+set(APP_TITLE "Wake It!")
+set(APP_DESCRIPTION "Send Wake-on-LAN magic packets")
+set(WAKEIT_DIR "share/qml/wakeit")
+set(MAIN_QML "${APP_NAME}.qml")
+set(APP_ICON "graphics/${APP_NAME}.png")
 
-set(CMAKE_AUTOMOC ON)
+set(APP_VERSION_MAJOR 0)
+set(APP_VERSION_MINOR 1)
+set(APP_VERSION_PATCH 4)
+set(APP_VERSION "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_PATCH}")
 
-# Configure and set the installation directory for the manifest file
-configure_file(manifest.json.in "${CMAKE_CURRENT_BINARY_DIR}/manifest.json")
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/manifest.json"
-    DESTINATION "${DATA_DIR}"
+# Set install paths
+set(CMAKE_INSTALL_PREFIX /)
+set(DATA_DIR /)
+set(DESKTOP_DIR ${DATA_DIR})
+set(APP_DESKTOP "${APP_NAME}.desktop")
+
+set(APP_EXEC "qmlscene $@ ${WAKEIT_DIR}/${MAIN_QML}")
+
+# Determine the name and arch triplet of the host
+execute_process(
+    COMMAND dpkg-architecture -qDEB_HOST_ARCH
+    OUTPUT_VARIABLE HOST_ARCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# Configure and set the installation directory for the manifest file
+configure_file(manifest.json.in ${CMAKE_CURRENT_BINARY_DIR}/manifest.json)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/manifest.json
+        DESTINATION ${CMAKE_INSTALL_PREFIX})
+
 # Install graphics and apparmor profile
-install(DIRECTORY "app/graphics" DESTINATION "${DATA_DIR}")
-install(FILES "${APP_NAME}.apparmor" DESTINATION "${DATA_DIR}")
+install(DIRECTORY "app/graphics" DESTINATION ${DATA_DIR})
+install(FILES "${APP_NAME}.apparmor" DESTINATION ${DATA_DIR})
 
 add_subdirectory(app)
 add_subdirectory(backend)
@@ -77,7 +79,7 @@ add_custom_target(
 )
 
 add_custom_target(
-    "run" /usr/bin/qmlscene -I "${CMAKE_BINARY_DIR}/backend" "${CMAKE_SOURCE_DIR}/app/${APP_QML}"
+    "run" /usr/bin/qmlscene -I "${CMAKE_BINARY_DIR}/backend" "${CMAKE_SOURCE_DIR}/app/${MAIN_QML}"
     DEPENDS WakeItBackend WakeItBackend-qmldir
     WORKING_DIRECTORY ./app
 )

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,12 +1,13 @@
 # Find all of the QML and JS files
 file(GLOB QML_JS_FILES *.qml *.js)
 
+
 # Configure the .desktop.in file
 configure_file("${APP_DESKTOP}.in" "${CMAKE_CURRENT_BINARY_DIR}/${APP_DESKTOP}.in")
 
 # Install the .desktop and QML files
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${APP_DESKTOP}" DESTINATION "${DATA_DIR}")
-install(FILES "${QML_JS_FILES}" DESTINATION "${DATA_DIR}")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${APP_DESKTOP}" DESTINATION ${DESKTOP_DIR})
+install(FILES ${QML_JS_FILES} DESTINATION ${WAKEIT_DIR})
 
 # No-op custom target for QML and JS files so that they show up in QtCreator
 add_custom_target("qml_and_js_files" ALL SOURCES ${QML_JS_FILES})

--- a/backend/src/device.cpp
+++ b/backend/src/device.cpp
@@ -105,7 +105,7 @@ bool Device::fromJson(const QJsonObject &object)
     mLocal = object.value("local").toBool();
     mHost = object.value("host").toString();
     mMac = object.value("mac").toString();
-    mPort = object.value("port").toInt();
+    mPort = object.value("port").toString().toUInt(); // QJsonObject.toInt() always return the default value
 
     return true;
 }


### PR DESCRIPTION
Since wakeit consists of 2 qml files, building click packages failed all the time. The changed CMakeLists files solve this. It is mainly a merge between vanilla CMakeList from the SDK example project with wakeit. Some variables where missing that are used for the install target. I do not know why it worked with 1 qml file.

The second commit solves the bug that the port is always 0, it does matter what you entered in the input field. The result is that never WOL messages were sent.

With both changes it is the first time that wakeit works for me :)
